### PR TITLE
add new module type MTB-UNIS

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ must also be described. This protocol is available [here](pc).
 4. [Workflows](workflows.md)
 5. Module-specific commands
    - [MTB-UNI](modules/uni.md)
+   - [MTB-UNIS](modules/unis.md)
    - MTB-BOOST
    - MTB-RAILCOM
    - MTB-CROS

--- a/module-types.md
+++ b/module-types.md
@@ -12,6 +12,7 @@ MTBbus module type is determined by its 1-byte *code*.
 | `0x20` | MTB-BOOST                                       |
 | `0x30` | MTB-RAILCOM                                     |
 | `0x40` | MTB-CROS                                        |
+| `0x50` | MTB-UNIS with ATmega128 and 6 servo outputs     |
 
 Note: this table must contain entry for each hardware revision of single module
 type if this revision affects uploaded firmware. Module type must fully qualify

--- a/modules/unis.md
+++ b/modules/unis.md
@@ -1,0 +1,153 @@
+MTB-UNI Module
+==============
+
+This specification applies for module types listed below:
+
+| Code   | Module type                                     |
+|--------|-------------------------------------------------|
+| `0x50` | MTB-UNIS with ATmega128 and 6 servo outputs     |
+
+MTB-UNIS module is much like MTB-UNI modules. It contains 16 digital inputs and
+16 digital outputs, and 6 servo outputs. Any of 16 digital output is capable of S-COM protocol
+transmission as well as flickering. Servo is controlled via aditional 12 virtual outputs
+
+## Outputs state
+
+State of each output is encoded in 1 byte:
+
+* `0b 1xxx xxxx`: S-COM code. `x`'s represent specific [S-COM
+  code](https://www.mtb-model.com/elektro/s-com.htm) (0-127).
+* `0b 0000 000x`: digital outputs + servo outputs.
+   - `x=0` = open collector,
+   - `x=1` = output grounded.
+* `0b 0100 xxxx`: flicker output. `xxxx`:
+   - 1: 1 Hz
+   - 2: 2 Hz
+   - 3: 3 Hz
+   - 4: 4 Hz
+   - 5: 5 Hz
+   - 6: 10 Hz
+   - 7: 33 tick/min
+   - 8: 66 tick/min
+
+## Configuration
+
+Configuration consists of 55 bytes. First `24` bytes are same as in MTB-UNI module.
+
+1. 16 bytes of safe outputs state (outputs indexed in order 0 to 15).
+2. 8 bytes of input keep delay.
+   - Byte 0: `0bBBBBAAAA`. `A` = delay of input 0, `B` = delay of input 1.
+   - Byte 1: delay of input 2, delay of input 3.
+   - ...
+   Each input has 16 values of input delay. `0`=0.0s, `1`=0.1s, `2`=0.2s, ...,
+   `15`=1.5s.
+3. 1 byte mask, which servo outputs are active
+   - `0b00654321`, 1 = output active, 0 = output disabled
+4. 24 bytes for servo positions
+   - 2 byte value for servo 1 position 1
+   - 2 byte value for servo 1 position 2
+   - 2 byte value for servo 2 position 1
+   - ...
+5. 6 bytes for servo speed
+   - speed for servo 1
+   - speed for servo 2
+   - ...
+   
+When input goes to logical 0, it must remain in this state for *input keep
+delay* to consider the input as logical 0. Only after the time input changed
+event is reported to master board.
+
+## Module-specific commands
+
+Master → slave:
+
+* *Set Configuration*: n.o. data bytes: 55. Whole configuration is sent.
+* *Get Configuration*: n.o. data bytes: 0.
+* *Get Input*: n.o. data bytes: 0.
+* *Set Output*: n.o. data bytes: variable.
+  - State of all outputs is always sent.
+  - Data byte 0: full state mask for outputs `0b00fedcba`.
+  - Data byte 1: full state mask for outputs `0bFEDCBA98`.
+  - Data byte 2: full state mask for outputs `0b76543210`.
+  - Data byte 3: binary state of outputs `0b00fedcba`.
+  - Data byte 4: binary state of outputs `0bFEDCBA98`.
+  - Data byte 5: binary state of outputs `0b76543210`.
+  - Data byte 6–n: state of full-state outputs in order 0–F.
+  - Examples (only data bytes are written):
+    - Set output 1 as active, other as inactive: `0x00 0x00 0x00 0x02`.
+    - Set output 8 to S-COM code `0x0A`, output 10 as flickering with period
+      2 Hz, output 15 as active, other as inactive:
+      `0x05 0x00 0xF0 0x00 0x42 0x8A`.
+  - Bits in *binary state output* which are masked by *full state mask* can
+    contain any value. This value is ignored.
+* *Firmware Write Flash*
+  - Data byte 0: first byte flash address high.
+  - Data byte 1: first byte flash address low.
+  - Data byte 2–65: 64 bytes of memory data.
+* *Module-specific command*
+  - Data byte 0 = `0x01` = set servo position.
+    - Data byte 1 = position identification `0b0nnn000p` where p = position, n = servo number
+    - Data byte 2 + byte 3 = new position for servo
+    (p = position  - 0=1st position, 1=2nd position, n = servo number - possible values 1-6)
+  - Data byte 0 = `0x02` = set servo speed.
+    - Data byte 1 = position identification `0b0nnn000p` where p = position, n = servo number
+    - Data byte 2 + byte 3: new speed for servo.
+    (p = position  - 0=1st position, 1=2nd position, n = servo number - possible values 1-6)
+  - Data byte 0 = `0x03` = manual setting of servo position (changes will not be saved to eeprom).
+    - Data byte 1 = position identification `0b0nnn0000` where n = servo number (1-6)
+    - Data byte 2 + byte 3: new position for servo.
+    servo immediately move to new position, ignore state of virtual outputs for servo
+    after inactivity ~1 minute, servo move to its original position - defined in eeprom and virtual outputs state
+  - Data byte 0 = `0x03` = manual setting of servo position (changes will not be saved to eeprom).
+    - Data byte 1 = 0 - end of manual position setting, all servos restore normal operation
+  
+  Manual servo positioning is for testing. No changes will be saved to internal eeprom.
+  Control application can save eeprom values via standard command *Set Configuration*  
+
+Slave → master:
+
+* *Module Configuration*: n.o. data bytes: 55. Whole configuration is sent.
+* *Input Changed*: n.o. data bytes: 2. Full state of inputs is sent.
+  - Data byte 0: inputs `0bFEDCBA98`.
+  - Data byte 1: inputs `0b76543210`.
+  - Order of inputs in byte: `0b76543210`.
+* *Input State*: n.o. data bytes: 2. Full state of inputs is sent.
+* *Output Set*: n.o. data bytes: variable. Same data bytes as in message *Set
+  Output* is sent.
+
+### Firmware upgrade
+
+Data is sent in frames of 64 bytes.
+
+* *Firmware Write Flash*
+  - Data byte 0: page address.
+  - Data byte 1: offset in page.
+  - Data byte 2–65: memory data.
+
+* *Firmware Write Flash Status*
+  - Data byte 1: page address.
+  - Data byte 2: offset in page.
+
+Page size is 256 bytes.
+Thus, for single page write 4 *Firmware Write Flash* commands must be
+sent:
+
+ 1. `0x01 0x43 0xF1 0x00 0x00 [64 bytes of data] [checksum]`
+ 2. `0x01 0x43 0xF1 0x00 0x40 [64 bytes of data] [checksum]`
+ 3. `0x01 0x43 0xF1 0x00 0x80 [64 bytes of data] [checksum]`
+ 4. `0x01 0x43 0xF1 0x00 0xC0 [64 bytes of data] [checksum]`
+
+Upgrade is done page-based. Frames in page need to be received in-order.
+Page is written when last frame of page is received. It is impossible to write
+just part of the page. In case when part of the page is supposed to be written,
+rest of the page must be padded.
+
+## Diagnostic information
+
+Module reports no errors.
+
+Module reports [common warnings](../diag.md) and some additional information:
+
+`14`: servo voltage - output of power voltage regulator
+ * Length: 2 bytes
+ * Representation: left justified value from internal ADC

--- a/requirements.md
+++ b/requirements.md
@@ -76,6 +76,20 @@ Požadavky na nový MTB protokol
      b. úroveň: 0b 0000 000x
      c. kmitání: 0b 0100 xxxx
 
+### MTB-UNIS
+
+ * Konfigurace:
+   - 16 bytů: typ výstupů + bezpečný stav
+   - 8 bytů: 16×4 bity: zpoždění vstupů per vstup po 0.1 s
+   - 1 byte: maska, jaké servovýstupy jsou aktivní (6 výstupů)
+   - 24 bytů: 6x2x2 bytů koncové polohy serv (6 serv, 2 polohy, 2 byte na polohu)
+   - 6 bytů: rychlost serv
+ * Stav vstupů se vždy posílá celý (2 bytes)
+ * Stav výstupů: 1 byte:
+     a. S-COM 0b 1xxx xxxx
+     b. úroveň: 0b 0000 000x - i pro serva, simulují se 2 výstupy na servo
+     c. kmitání: 0b 0100 xxxx
+     
 ### MTB-SPAX
 
  * Vstupy:


### PR DESCRIPTION
Added now module type with id=0x50. 
Module is based on MTB-UNI, but can drive up to 6 servos.